### PR TITLE
Add automated PDF download helper and UI toggle

### DIFF
--- a/Readme
+++ b/Readme
@@ -5,22 +5,24 @@ scriptable browser.
 
 ## How it works
 
-1. Launch the application and paste the article URL in the **Article URL** field.
+1. Launch the application and paste your bibliography entries (including the DOIs or
+   article links) into the **Bibliography entries** text box.
 2. Click **Prepare automation dependencies** if you want the in-app helper to install
    Playwright and the bundled Chromium browser into the interpreter that is currently
    running the GUI (no external terminal required). The button is safe to press even
    if everything is already installed—it simply verifies the setup.
 3. Pick a downloads folder, then decide how you want to grab the PDF:
    - Leave **Attempt automatic PDF download** unchecked to follow the existing flow.
-     The app will open a file picker so you can select the PDF that you downloaded
-     manually in your regular browser.
+     After you download the bibliography PDF manually, the app will open a file picker
+     so you can select the file from the chosen downloads folder.
    - Check **Attempt automatic PDF download** to let the helper spin up a Playwright
-     browser session. After the page loads you have a short window to complete any
-     authentication, and the helper will then try to click common “PDF” or
-     “Download” buttons automatically. When a download succeeds the file is saved to
-     the configured downloads folder and the manual picker is skipped.
-4. If automation cannot run or fails to find a PDF link, the application falls back
-   to the manual dialog so you can select the file yourself.
+     browser session. It will walk through every link discovered in the bibliography,
+     waiting briefly for you to complete authentication if needed, and then try to
+     click common “PDF” or “Download” buttons automatically. When a download succeeds
+     the file is saved to the configured downloads folder and the manual picker is
+     skipped.
+4. If automation cannot run or fails to find a PDF link for every entry, the
+   application falls back to the manual dialog so you can select the file yourself.
 
 ## Installation
 

--- a/Readme
+++ b/Readme
@@ -1,1 +1,50 @@
-temp
+# Fetch Literature
+
+A minimal desktop helper for collecting bibliography PDFs using manual selection or a
+scriptable browser.
+
+## How it works
+
+1. Launch the application and paste the article URL in the **Article URL** field.
+2. Pick a downloads folder, then decide how you want to grab the PDF:
+   - Leave **Attempt automatic PDF download** unchecked to follow the existing flow.
+     The app will open a file picker so you can select the PDF that you downloaded
+     manually in your regular browser.
+   - Check **Attempt automatic PDF download** to let the helper spin up a Playwright
+     browser session. After the page loads you have a short window to complete any
+     authentication, and the helper will then try to click common “PDF” or
+     “Download” buttons automatically. When a download succeeds the file is saved to
+     the configured downloads folder and the manual picker is skipped.
+3. If automation cannot run (for example, Playwright is not installed) or fails to
+   find a PDF link, the application falls back to the manual dialog so you can select
+   the file yourself.
+
+## Installation
+
+```bash
+pip install playwright           # install the automation runtime
+playwright install chromium      # download the controllable Chromium browser
+```
+
+Tkinter ships with the CPython standard library on most platforms. If your Python
+distribution omits it, install the appropriate OS-specific package.
+
+## Configuration
+
+- **Default downloads directory:** set in code via `FetcherConfig` or by browsing to a
+  folder in the UI. The application remembers the folder for the current session.
+- **Automatic download toggle:** exposed as a checkbox in the UI and can be set
+  programmatically with `FetcherConfig(automation_default=True)` for deployments where
+  Playwright is guaranteed to be available.
+- **Browser choice:** the automation helper defaults to Playwright’s Chromium engine.
+  You can call `attempt_automated_pdf_download(..., browser="firefox")` if you need a
+  different backend.
+
+## Development
+
+```bash
+python -m compileall fetch_literature
+```
+
+The `browser_automation.py` helper uses Playwright’s async APIs; consult the Playwright
+[Python documentation](https://playwright.dev/python/) for additional selector ideas.

--- a/Readme
+++ b/Readme
@@ -6,7 +6,11 @@ scriptable browser.
 ## How it works
 
 1. Launch the application and paste the article URL in the **Article URL** field.
-2. Pick a downloads folder, then decide how you want to grab the PDF:
+2. Click **Prepare automation dependencies** if you want the in-app helper to install
+   Playwright and the bundled Chromium browser into the interpreter that is currently
+   running the GUI (no external terminal required). The button is safe to press even
+   if everything is already installed—it simply verifies the setup.
+3. Pick a downloads folder, then decide how you want to grab the PDF:
    - Leave **Attempt automatic PDF download** unchecked to follow the existing flow.
      The app will open a file picker so you can select the PDF that you downloaded
      manually in your regular browser.
@@ -15,15 +19,22 @@ scriptable browser.
      authentication, and the helper will then try to click common “PDF” or
      “Download” buttons automatically. When a download succeeds the file is saved to
      the configured downloads folder and the manual picker is skipped.
-3. If automation cannot run (for example, Playwright is not installed) or fails to
-   find a PDF link, the application falls back to the manual dialog so you can select
-   the file yourself.
+4. If automation cannot run or fails to find a PDF link, the application falls back
+   to the manual dialog so you can select the file yourself.
 
 ## Installation
 
+You can install everything from inside the GUI by pressing
+**Prepare automation dependencies**. The helper runs `python -m pip install
+playwright` followed by `python -m playwright install chromium` using the exact
+interpreter that launched the app, so PyCharm virtual environments work without
+opening a shell.
+
+Prefer to manage dependencies manually? Run the same commands yourself:
+
 ```bash
-pip install playwright           # install the automation runtime
-playwright install chromium      # download the controllable Chromium browser
+python -m pip install playwright
+python -m playwright install chromium
 ```
 
 Tkinter ships with the CPython standard library on most platforms. If your Python

--- a/fetch_literature/__init__.py
+++ b/fetch_literature/__init__.py
@@ -1,0 +1,5 @@
+"""Fetch Literature application package."""
+
+from .fetcher_app import FetcherApp
+
+__all__ = ["FetcherApp"]

--- a/fetch_literature/__init__.py
+++ b/fetch_literature/__init__.py
@@ -1,5 +1,6 @@
 """Fetch Literature application package."""
 
+from .browser_automation import ensure_playwright_setup
 from .fetcher_app import FetcherApp
 
-__all__ = ["FetcherApp"]
+__all__ = ["FetcherApp", "ensure_playwright_setup"]

--- a/fetch_literature/browser_automation.py
+++ b/fetch_literature/browser_automation.py
@@ -1,0 +1,153 @@
+"""Helpers for driving a browser to fetch bibliography PDFs automatically."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+DEFAULT_SELECTORS: tuple[str, ...] = (
+    "a[download]",
+    "a[href$='.pdf']",
+    "a:has-text(\"PDF\")",
+    "a:has-text(\"Download PDF\")",
+    "button:has-text(\"PDF\")",
+    "button:has-text(\"Download\")",
+    "a:has-text(\"Full Text\")",
+)
+
+
+@dataclass
+class AutomationResult:
+    """Outcome of a single automation attempt."""
+
+    attempted: bool
+    path: Optional[Path] = None
+    error: Optional[str] = None
+    logs: List[str] = field(default_factory=list)
+
+    def record(self, message: str) -> None:
+        self.logs.append(message)
+
+
+async def _run_in_browser(
+    candidate_url: str,
+    download_path: Path,
+    *,
+    browser: str,
+    selectors: Sequence[str],
+    headless: bool,
+    login_wait_seconds: float,
+    click_timeout_seconds: float,
+    result: AutomationResult,
+) -> Optional[Path]:
+    from playwright.async_api import TimeoutError as PlaywrightTimeoutError  # type: ignore
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as playwright:
+        try:
+            browser_type = getattr(playwright, browser)
+        except AttributeError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"Unsupported browser '{browser}'") from exc
+
+        launched_browser = await browser_type.launch(headless=headless)
+        try:
+            context = await launched_browser.new_context(accept_downloads=True)
+            try:
+                page = await context.new_page()
+                await page.goto(candidate_url, wait_until="load")
+                if login_wait_seconds:
+                    await page.wait_for_timeout(int(login_wait_seconds * 1000))
+
+                errors: List[str] = []
+                for selector in selectors:
+                    locator = page.locator(selector)
+                    try:
+                        if await locator.count() == 0:
+                            continue
+
+                        async with page.expect_download(timeout=int(click_timeout_seconds * 1000)) as download_info:
+                            await locator.first.click()
+                        download = await download_info.value
+                        suggested = download.suggested_filename or "bibliography.pdf"
+                        target = download_path / suggested
+                        await download.save_as(str(target))
+                        result.record(f"Downloaded via selector '{selector}' -> {target}")
+                        return target
+                    except PlaywrightTimeoutError:
+                        errors.append(f"No download triggered after clicking '{selector}'.")
+                    except Exception as exc:  # pragma: no cover - best effort logging
+                        errors.append(f"Error clicking '{selector}': {exc}")
+
+                if errors:
+                    result.error = "\n".join(errors)
+                return None
+            finally:
+                await context.close()
+        finally:
+            await launched_browser.close()
+
+
+def attempt_automated_pdf_download(
+    candidate_url: str,
+    *,
+    download_dir: Path | None = None,
+    browser: str = "chromium",
+    selectors: Sequence[str] | None = None,
+    headless: bool = True,
+    login_wait_seconds: float = 12.0,
+    click_timeout_seconds: float = 8.0,
+) -> AutomationResult:
+    """Attempt to fetch a bibliography PDF using Playwright."""
+
+    if not candidate_url:
+        return AutomationResult(attempted=False, error="No URL provided for automated download.")
+
+    try:
+        import importlib
+
+        importlib.import_module("playwright.async_api")
+    except ImportError:
+        return AutomationResult(
+            attempted=False,
+            error=(
+                "Playwright is not installed. Install it with 'pip install playwright' "
+                "and run 'playwright install chromium' to set up the browser runtime."
+            ),
+        )
+
+    download_path = Path(download_dir or Path.cwd() / "downloads")
+    download_path.mkdir(parents=True, exist_ok=True)
+
+    selectors_to_try = list(dict.fromkeys((selectors or []) + list(DEFAULT_SELECTORS)))
+    result = AutomationResult(attempted=True)
+
+    coroutine = _run_in_browser(
+        candidate_url,
+        download_path,
+        browser=browser,
+        selectors=selectors_to_try,
+        headless=headless,
+        login_wait_seconds=login_wait_seconds,
+        click_timeout_seconds=click_timeout_seconds,
+        result=result,
+    )
+
+    try:
+        path = asyncio.run(coroutine)
+    except RuntimeError as runtime_error:  # pragma: no cover - nested loop fallback
+        if "event loop" in str(runtime_error).lower():
+            loop = asyncio.new_event_loop()
+            try:
+                path = loop.run_until_complete(coroutine)
+            finally:
+                loop.close()
+        else:
+            raise
+
+    result.path = path
+    return result
+
+
+__all__ = ["AutomationResult", "attempt_automated_pdf_download"]

--- a/fetch_literature/fetcher_app.py
+++ b/fetch_literature/fetcher_app.py
@@ -10,11 +10,18 @@ from typing import Optional
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
-from .browser_automation import (
-    AutomationResult,
-    attempt_automated_pdf_download,
-    ensure_playwright_setup,
-)
+if __package__:
+    from .browser_automation import (
+        AutomationResult,
+        attempt_automated_pdf_download,
+        ensure_playwright_setup,
+    )
+else:  # When executed as a stand-alone script.
+    from fetch_literature.browser_automation import (
+        AutomationResult,
+        attempt_automated_pdf_download,
+        ensure_playwright_setup,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/fetch_literature/fetcher_app.py
+++ b/fetch_literature/fetcher_app.py
@@ -1,0 +1,152 @@
+"""Tkinter GUI for assisting with literature PDF downloads."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from .browser_automation import AutomationResult, attempt_automated_pdf_download
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FetcherConfig:
+    """Runtime configuration for :class:`FetcherApp`."""
+
+    default_download_dir: Path = Path.home() / "Downloads"
+    automation_default: bool = False
+
+
+class FetcherApp:
+    """Tkinter front-end for coordinating bibliography downloads."""
+
+    def __init__(self, root: tk.Tk | tk.Toplevel, config: FetcherConfig | None = None) -> None:
+        self.root = root
+        self.config = config or FetcherConfig()
+
+        self.url_var = tk.StringVar()
+        self.download_dir_var = tk.StringVar(value=str(self.config.default_download_dir))
+        self.automation_enabled = tk.BooleanVar(value=self.config.automation_default)
+        self.status_var = tk.StringVar(value="Ready")
+
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction helpers
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        self.root.title("Fetch Literature")
+
+        container = ttk.Frame(self.root, padding=12)
+        container.grid(column=0, row=0, sticky="nsew")
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(0, weight=1)
+
+        ttk.Label(container, text="Article URL:").grid(column=0, row=0, sticky="w")
+        ttk.Entry(container, textvariable=self.url_var, width=60).grid(
+            column=1, row=0, columnspan=2, sticky="ew", padx=(8, 0)
+        )
+        container.columnconfigure(1, weight=1)
+
+        ttk.Label(container, text="Downloads folder:").grid(column=0, row=1, sticky="w", pady=(8, 0))
+        ttk.Entry(container, textvariable=self.download_dir_var, width=60).grid(
+            column=1, row=1, sticky="ew", padx=(8, 0), pady=(8, 0)
+        )
+        ttk.Button(container, text="Browse…", command=self._prompt_download_directory).grid(
+            column=2, row=1, padx=(8, 0), pady=(8, 0)
+        )
+
+        ttk.Checkbutton(
+            container,
+            text="Attempt automatic PDF download (requires Playwright)",
+            variable=self.automation_enabled,
+        ).grid(column=0, row=2, columnspan=3, sticky="w", pady=(12, 0))
+
+        ttk.Button(container, text="Download bibliography", command=self.download_bibliography).grid(
+            column=0, row=3, columnspan=3, pady=(16, 0)
+        )
+
+        ttk.Label(container, textvariable=self.status_var, foreground="#444444").grid(
+            column=0, row=4, columnspan=3, sticky="w", pady=(12, 0)
+        )
+
+    # ------------------------------------------------------------------
+    # Core behaviour
+    # ------------------------------------------------------------------
+    def download_bibliography(self) -> Optional[Path]:
+        """Download the bibliography PDF using automation when available."""
+
+        url = self.url_var.get().strip()
+        if not url:
+            messagebox.showerror("Missing URL", "Please enter the article URL before downloading.")
+            return None
+
+        download_dir = Path(self.download_dir_var.get()).expanduser().resolve()
+        download_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.debug("Initiating download for %s", url)
+
+        if self.automation_enabled.get():
+            result: AutomationResult = attempt_automated_pdf_download(
+                candidate_url=url,
+                download_dir=download_dir,
+            )
+            if result.path:
+                self.status_var.set(f"Downloaded automatically: {result.path}")
+                messagebox.showinfo("Download complete", f"Automatically downloaded PDF to {result.path}")
+                return result.path
+
+            if result.attempted:
+                details = result.error or "Unable to locate a PDF link automatically."
+                messagebox.showwarning(
+                    "Automatic download unavailable",
+                    f"The automated browser could not complete the download.\n\n{details}\n"
+                    "Please use the manual file picker instead.",
+                )
+            elif result.error:
+                messagebox.showinfo(
+                    "Automation not available",
+                    f"Automatic downloads were skipped because: {result.error}\n"
+                    "The manual file picker will be shown instead.",
+                )
+
+        selected_path = self.request_manual_download(download_dir)
+        if selected_path:
+            self.status_var.set(f"Using manually selected file: {selected_path}")
+        else:
+            self.status_var.set("No PDF selected yet")
+        return selected_path
+
+    def request_manual_download(self, download_dir: Path) -> Optional[Path]:
+        """Prompt the user to manually choose a downloaded bibliography file."""
+
+        file_path = filedialog.askopenfilename(
+            parent=self.root,
+            title="Select the downloaded bibliography PDF",
+            initialdir=str(download_dir),
+            filetypes=[("PDF files", "*.pdf"), ("All files", "*")],
+        )
+        if not file_path:
+            return None
+
+        pdf_path = Path(file_path)
+        messagebox.showinfo("Bibliography selected", f"Using {pdf_path}")
+        return pdf_path
+
+    # ------------------------------------------------------------------
+    # Helper callbacks
+    # ------------------------------------------------------------------
+    def _prompt_download_directory(self) -> None:
+        current = Path(self.download_dir_var.get()).expanduser()
+        chosen = filedialog.askdirectory(parent=self.root, initialdir=str(current), title="Select downloads folder")
+        if chosen:
+            self.download_dir_var.set(chosen)
+
+
+__all__ = ["FetcherApp", "FetcherConfig"]

--- a/fetch_literature/fetcher_app.py
+++ b/fetch_literature/fetcher_app.py
@@ -188,4 +188,16 @@ class FetcherApp:
             self.status_var.set("Automation setup encountered an error")
 
 
-__all__ = ["FetcherApp", "FetcherConfig"]
+def main() -> None:
+    """Launch the Fetcher GUI."""
+
+    root = tk.Tk()
+    FetcherApp(root)
+    root.mainloop()
+
+
+__all__ = ["FetcherApp", "FetcherConfig", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - GUI entry point
+    main()


### PR DESCRIPTION
## Summary
- add a Playwright-powered `browser_automation` helper that can click PDF download buttons and return saved files
- expose an automation toggle in `FetcherApp.download_bibliography` so successful automation bypasses the manual dialog
- update the documentation to describe the automation flow, optional dependency, and configuration options

## Testing
- python -m compileall fetch_literature

------
https://chatgpt.com/codex/tasks/task_b_68dea92fbe74832c9271000d5f0a9c1a