### PR TITLE
Add manual fallback option for missed downloads

### DIFF
--- a/Readme
+++ b/Readme
@@ -1,1 +1,41 @@
-temp
+# Fetch Literature PDFs
+
+This repository provides a small Tkinter + Selenium utility that can automate downloading PDFs referenced in a bibliography.
+
+## Requirements
+
+- Python 3.9+
+- Firefox browser (since Chrome is not available)
+- `geckodriver` available on your system `PATH`
+- Python dependencies: `selenium`
+
+Install dependencies with:
+
+```bash
+pip install selenium
+```
+
+## Usage
+
+1. Run the script (for example from PyCharm):
+
+   ```bash
+   python fetch_pdfs.py
+   ```
+
+2. Paste bibliography entries into the text box. Entries can be separated by blank lines **or** by numbering such as `[1]`, `(2)`, or `3.`—the parser will split them accordingly.
+3. Choose the destination folder for the downloaded PDFs (defaults to a folder on your Desktop) and, if desired, adjust the per-reference download timeout (30 seconds by default). Enable **Offer manual browser fallback for missed PDFs** if you would like the app to prompt you to finish any stubborn downloads yourself.
+4. Click **Download PDFs**. The application will launch Firefox, search each reference on Google Scholar, follow the first result, download the associated PDF, and save it into the chosen folder. Each file is named after the detected study title when possible (falling back to a numeric sequence otherwise). Use the **Skip ▶** control if you need to manually advance to the next reference without waiting for the active attempt to finish.
+   - If Google Scholar interrupts with a verification step (for example an “I'm not a robot” challenge), the app pauses and shows a dialog. Complete the verification manually in Firefox and press **OK** to continue.
+5. When finished, a summary dialog displays the results. Any references that fail
+   on the first pass are automatically retried once more before the summary is
+   shown. If any PDFs still cannot be downloaded, a `missing_pdfs.txt` report is
+   written to the destination folder listing the references and the reason they
+   were skipped.
+
+   - If the manual fallback option is enabled, the app opens the remaining
+     references in your default browser and watches your **Downloads** folder
+     for a new PDF. As soon as a file appears there, it is moved into the chosen
+     destination and renamed to match the reference title.
+
+Downloads occur through Firefox so they retain any session-based access you have in your browser profile.


### PR DESCRIPTION
## Summary
- add an optional manual fallback checkbox in the GUI to retry failed references through the user's browser
- detect freshly downloaded PDFs in the user's Downloads folder and move them into the destination directory
- document the manual fallback workflow and expose helpers for the download directory and manual polling

## Testing
- python - <<'PY'
from pathlib import Path
import tempfile
import threading
import time

from fetch_pdfs import (
    DownloadResult,
    SkipRequested,
    PDFDownloader,
    create_failure_report,
    derive_title,
    extract_references,
    page_requires_verification,
    wait_for_manual_pdf,
    _merge_failure_messages,
)

sample = """[1] Keilbart, N.; Okada, Y.; Dabo, I. Probing the pseudocapacitance and energy-storage performance of RuO2 facets from first principles. Phys. Rev. Materials 2019, 3, 085405. https://doi.org/10.1103/PhysRevMaterials.3.085405
[2] Tomkiewicz, M.; Huang, Y. S.; Pollak, F. H. The Potential of Zero Charge of Oriented Single‐Crystal RuO2 in Aqueous Electrolytes. J. Electrochem. Soc. 1983, 130, 1514. https://doi.org/10.1149/1.2120022
[3] Bonnet, N.; Marzari, N. First-Principles Prediction of the Equilibrium Shape of Nanoparticles Under Realistic Electrochemical Conditions. Phys. Rev. Lett. 2013, 110, 086104. https://doi.org/10.1103/PhysRevLett.110.086104"""

refs = extract_references(sample)
assert len(refs) == 3
assert derive_title(refs[0]).startswith("Probing the pseudocapacitance")
assert derive_title(refs[1]).startswith("The Potential of Zero Charge")
assert derive_title(refs[2]).startswith("First-Principles Prediction")

merged = _merge_failure_messages("No results", "Timed out")
assert merged == "initial attempt: No results; retry attempt: Timed out"
assert _merge_failure_messages("", "") == ""

# Verify skip helper raises when event is set.
skip_event = threading.Event()
skip_event.set()
try:
    PDFDownloader._check_skip(skip_event)
except SkipRequested:
    pass
else:
    raise AssertionError("SkipRequested was not raised")

skip_event.clear()
PDFDownloader._check_skip(skip_event)

html_sample = "<html><body><h1>I'm not a robot</h1><div class='g-recaptcha'></div></body></html>"
assert page_requires_verification(html_sample, "https://scholar.google.com/")
assert page_requires_verification(
    "Our systems have detected unusual traffic", "https://scholar.google.com/sorry/index"
)
assert not page_requires_verification(
    "<div>Regular results</div>", "https://scholar.google.com/scholar?hl=en&q=test"
)

with tempfile.TemporaryDirectory() as tmp_dir:
    tmp_path = Path(tmp_dir)
    report_path = create_failure_report(
        tmp_path,
        [
            DownloadResult(refs[0], False, "No Google Scholar results were found"),
            DownloadResult(refs[1], False, "Download did not complete in time"),
        ],
    )
    assert report_path is not None
    content = report_path.read_text(encoding="utf-8")
    assert "No Google Scholar results were found" in content
    assert "Download did not complete in time" in content

manual_dir = Path(tempfile.mkdtemp())
existing_pdf = manual_dir / "existing.pdf"
existing_pdf.write_bytes(b"existing")
existing_set = {p.resolve() for p in manual_dir.glob("*.pdf")}

def delayed_create() -> None:
    time.sleep(0.5)
    (manual_dir / "manual.pdf").write_bytes(b"manual")

threading.Thread(target=delayed_create, daemon=True).start()
found = wait_for_manual_pdf(manual_dir, existing_set, timeout=3)
assert found is not None and found.name == "manual.pdf"

print("ok")
PY

------
https://chatgpt.com/codex/tasks/task_b_68dec243cdc8832ca26366ab5c4959e7