### PR TITLE
Improve PDF text extraction and add requirements

### DIFF
--- a/Readme
+++ b/Readme
@@ -7,13 +7,18 @@ This repository provides a small Tkinter + Selenium utility that can automate do
 - Python 3.9+
 - Firefox browser
 - Matching WebDriver binary on your system `PATH` (`geckodriver` for Firefox)
-- Python dependencies: `selenium`, `PyPDF2`
+- Python dependencies: `selenium`, `PyPDF2`, `pdfminer.six`
 
 Install dependencies with:
 
 ```bash
-pip install selenium PyPDF2
+pip install -r requirements.txt
 ```
+
+`pdfminer.six` is now used for significantly cleaner text extraction when building
+`combined_references.txt`. The tool automatically falls back to the legacy
+PyPDF2-based extractor if pdfminer is unavailable, but the new dependency is
+strongly recommended.
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+selenium
+PyPDF2
+pdfminer.six


### PR DESCRIPTION
## Summary
- integrate pdfminer.six-based parsing with heuristics to retain narrative text, figure captions, and references while stripping headers/footers
- fall back to the legacy PyPDF2 extractor when necessary and emit guidance about installing pdfminer for best results
- document the new dependency and add a requirements.txt so the branch is self-contained

## Testing
- python -m compileall fetch_pdfs.py

------
https://chatgpt.com/codex/tasks/task_e_68ed3db7bc8c832586593613e18b779d